### PR TITLE
Fix DTS for Orange Pi Zero

### DIFF
--- a/dts/opizero_st7796.dts
+++ b/dts/opizero_st7796.dts
@@ -4,52 +4,50 @@
 / {
     compatible = "allwinner,sun8i-h3";
 
-	fragment@0 {
-		target = <&spi1>;
-		__overlay__ {
-			num-cs = <2>;
-			/* CS0 PA10  CS1 PA13 */
-            cs-gpios = <&pio 0 10 0>,
-					   <&pio 0 13 0>;
-			status = "okay";
-			#address-cells = <1>;
-			#size-cells = <0>;
+        fragment@0 {
+                target = <&spi1>;
+                __overlay__ {
+                        num-cs = <2>;
+                        /* CS0 PA10  CS1 PA13 */
+                        cs-gpios = <&pio 0 10 0>,
+                                           <&pio 0 13 0>;
+                        status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
 
-			st7789v: st7789v@0{
-				compatible = "sitronix,st7796s";
-				/* CS 0 */
-                reg = <0>;
-				spi-max-frequency = <1000000>;
-				rotation = <180>;
-				fps = <30>;
-				buswidth = <8>;
-				reset-gpios = <&pio 0 2 0>; /* PA2 */
-				dc-gpios = <&pio 0 18 0>;  /* PA18 */
-				debug = <1>;
-			};
+                        st7789v: st7789v@0{
+                                compatible = "sitronix,st7796s";
+                                /* CS 0 */
+                                reg = <1>;
+                                spi-max-frequency = <1600000>;
+                                rotate = <270>;
+                                fps = <30>;
+                                buswidth = <8>;
+                                reset-gpios = <&pio 0 2 0>; /* PA2 */
+                                dc-gpios = <&pio 0 18 0>;  /* PA18 */
+                                debug = <1>;
+                        };
 
-			ads7846: ads7846@0 {
-				compatible = "ti,ads7846";
-				/* CS1 */
-                reg = <1>; 
-				status = "okay";
-				spi-max-frequency = <1600000>;
-				interrupt-parent = <&pio>;
-                interrupts = <0 1 2>; /* PA1 IRQ_TYPE_EDGE_FALLING */
-                pendown-gpio = <&pio 0 1 0>; /* PA1 */
+                        ads7846: ads7846@0 {
+                                compatible = "ti,ads7846";
+                                /* CS1 */
+                                reg = <0>;
+                                status = "okay";
+                                spi-max-frequency = <1600000>;
+                                interrupt-parent = <&pio>;
+                                interrupts = <0 1 2>; /* PA1 IRQ_TYPE_EDGE_FALLING */
+                                pendown-gpio = <&pio 0 1 0>; /* PA1 */
 
-				/* driver defaults, optional */
-				ti,x-min = /bits/ 16 <0>;
-				ti,y-min = /bits/ 16 <0>;
-				ti,x-max = /bits/ 16 <0x0FFF>;
-				ti,y-max = /bits/ 16 <0x0FFF>;
-				ti,pressure-min = /bits/ 16 <0>;
-				ti,pressure-max = /bits/ 16 <0xFFFF>;
-				ti,x-plate-ohms = /bits/ 16 <400>;
-		};
+                                /* driver defaults, optional */
+                                ti,x-min = /bits/ 16 <0>;
+                                ti,y-min = /bits/ 16 <0>;
+                                ti,x-max = /bits/ 16 <0x0FFF>;
+                                ti,y-max = /bits/ 16 <0x0FFF>;
+                                ti,pressure-min = /bits/ 16 <0>;
+                                ti,pressure-max = /bits/ 16 <0xFFFF>;
+                                ti,x-plate-ohms = /bits/ 16 <400>;
+                        };
 
-		};
-	};
-
-
+                };
+        };
 };


### PR DESCRIPTION
Проверил на своей Zero, была ошибка (или опечатка) в DTS файле, из-за которого не получалось запустить дисплей. Поправил, дисплей и тач запустились. Конфиг проверен лично, на двух одноплатниках.

Думаю может пригодится, на Orange Pi One (тоже с H3 процессором) думаю тоже актуально, GPIO одинаковый у них должен быть.

 